### PR TITLE
Fixed MvcPlugin to respect configured tenant

### DIFF
--- a/ReallySimpleFeatureToggle.Web.Mvc.Test.Unit/App.config
+++ b/ReallySimpleFeatureToggle.Web.Mvc.Test.Unit/App.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <configSections>
+    <section name="features" type="ReallySimpleFeatureToggle.Configuration.AppConfigProvider.FeatureConfigurationSection, ReallySimpleFeatureToggle" />
+  </configSections>
+
+  <features>
+    <add name="EnabledFeature" state="Enabled" />
+    <add name="DisabledFeature" state="Disabled" />
+  </features>
+
+</configuration>

--- a/ReallySimpleFeatureToggle.Web.Mvc.Test.Unit/MvcPluginTests/When_constructing.cs
+++ b/ReallySimpleFeatureToggle.Web.Mvc.Test.Unit/MvcPluginTests/When_constructing.cs
@@ -1,0 +1,40 @@
+﻿using Moq;
+using NUnit.Framework;
+using ReallySimpleFeatureToggle.FeatureStateEvaluation;
+using ReallySimpleFeatureToggle.Web.FeatureStateEvaluation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ReallySimpleFeatureToggle.Web.Mvc.Test.Unit.MvcPluginTests
+{
+    [TestFixture]
+    public class When_constructing
+    {
+        string _testTenant;
+        private Mock<IEvaluationContextBuilder> _mockEvaluationContext;
+
+        [SetUp]
+        public void Setup()
+        {
+            _testTenant = "DEV1";
+
+        }
+
+        public void Because()
+        {
+            var mvcPlugin = new MvcPlugin(_testTenant);
+        }
+
+
+        [Test]
+        public void Should_set_static_tenant_field()
+        {
+            Because();
+
+            Assert.That(MvcPlugin._tenant, Is.EqualTo(_testTenant));
+        }
+    }
+}

--- a/ReallySimpleFeatureToggle.Web.Mvc.Test.Unit/MvcPluginTests/When_returning_cached_features.cs
+++ b/ReallySimpleFeatureToggle.Web.Mvc.Test.Unit/MvcPluginTests/When_returning_cached_features.cs
@@ -1,0 +1,48 @@
+﻿using Moq;
+using NUnit.Framework;
+using ReallySimpleFeatureToggle.FeatureStateEvaluation;
+using ReallySimpleFeatureToggle.Web.FeatureStateEvaluation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web;
+
+namespace ReallySimpleFeatureToggle.Web.Mvc.Test.Unit.MvcPluginTests
+{
+    [TestFixture]
+    public class When_returning_cached_features
+    {
+        string _testTenant;
+        private Mock<IEvaluationContextBuilder> _mockEvaluationContext;
+
+        [SetUp]
+        public void SetUp()
+        {
+
+            _testTenant = "DEV1";
+            _mockEvaluationContext = new Mock<IEvaluationContextBuilder>();
+            _mockEvaluationContext.Setup(x => x.Create(It.IsAny<string>())).Returns(new EvaluationContext());
+            HttpContext.Current = new HttpContext(new HttpRequest("", "http://www.bing.com", ""), new HttpResponse(null));
+
+            var mvcPlugin = new MvcPlugin(_testTenant);
+            ReallySimpleFeature.Toggles.Configure
+                .WithPlugin(mvcPlugin)
+                .WithEvaluationContextOf<EvaluationContextForWebProjects>(_mockEvaluationContext.Object);
+        }
+
+        public void Because()
+        {
+            WhenEnabled.GetFeatureConfiguration();
+        }
+
+        [Test]
+        public void Should_pass_tenant_to_context_builder()
+        {
+            Because();
+
+            _mockEvaluationContext.Verify(x => x.Create(_testTenant));
+        }
+    }
+}

--- a/ReallySimpleFeatureToggle.Web.Mvc.Test.Unit/Properties/AssemblyInfo.cs
+++ b/ReallySimpleFeatureToggle.Web.Mvc.Test.Unit/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ReallySimpleFeatureToggle.Web.Mvc.Test.Unit")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ReallySimpleFeatureToggle.Web.Mvc.Test.Unit")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("17ce97e4-874f-4cc1-8c7b-7e03573cf0da")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/ReallySimpleFeatureToggle.Web.Mvc.Test.Unit/ReallySimpleFeatureToggle.Web.Mvc.Test.Unit.csproj
+++ b/ReallySimpleFeatureToggle.Web.Mvc.Test.Unit/ReallySimpleFeatureToggle.Web.Mvc.Test.Unit.csproj
@@ -1,0 +1,113 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{28A15B26-1A93-45FB-A06E-8FE0B85E726B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ReallySimpleFeatureToggle.Web.Mvc.Test.Unit</RootNamespace>
+    <AssemblyName>ReallySimpleFeatureToggle.Web.Mvc.Test.Unit</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Moq">
+      <HintPath>..\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework">
+      <HintPath>..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Web" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise />
+  </Choose>
+  <ItemGroup>
+    <Compile Include="MvcPluginTests\When_constructing.cs" />
+    <Compile Include="MvcPluginTests\When_returning_cached_features.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ReallySimpleFeatureToggle.Web.Mvc\ReallySimpleFeatureToggle.Web.Mvc.csproj">
+      <Project>{9d604f95-fff7-463f-a583-05377787e3ef}</Project>
+      <Name>ReallySimpleFeatureToggle.Web.Mvc</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\ReallySimpleFeatureToggle.Web\ReallySimpleFeatureToggle.Web.csproj">
+      <Project>{1548e6cf-a71e-45ca-90b9-4773db4ebde2}</Project>
+      <Name>ReallySimpleFeatureToggle.Web</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\ReallySimpleFeatureToggle\ReallySimpleFeatureToggle.csproj">
+      <Project>{300b92ef-79af-4225-83b3-d89f9995f357}</Project>
+      <Name>ReallySimpleFeatureToggle</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/ReallySimpleFeatureToggle.Web.Mvc.Test.Unit/packages.config
+++ b/ReallySimpleFeatureToggle.Web.Mvc.Test.Unit/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Moq" version="4.0.10827" targetFramework="net45" />
+  <package id="NUnit" version="2.6.2" targetFramework="net45" />
+</packages>

--- a/ReallySimpleFeatureToggle.Web.Mvc/MvcPlugin.cs
+++ b/ReallySimpleFeatureToggle.Web.Mvc/MvcPlugin.cs
@@ -5,6 +5,12 @@ namespace ReallySimpleFeatureToggle.Web.Mvc
 {
     public class MvcPlugin : IPluginBootstrapper
     {
+        internal static string _tenant;
+        public MvcPlugin(string tenant = null)
+        {
+            _tenant = tenant;
+        }
+
         private static string FeatureCacheKey
         {
             get { return "ReallySimpleFeatureToggle.Web.Mvc.MvcPlugin.FeatureCache"; }
@@ -23,7 +29,7 @@ namespace ReallySimpleFeatureToggle.Web.Mvc
                 return (IFeatureConfiguration)HttpContext.Current.Items[FeatureCacheKey];
             }
 
-            var config = ReallySimpleFeature.Toggles.GetFeatureConfiguration();
+            var config = ReallySimpleFeature.Toggles.GetFeatureConfiguration(_tenant);
             HttpContext.Current.Items[FeatureCacheKey] = config;
             
             return config;

--- a/ReallySimpleFeatureToggle.Web.Mvc/Properties/AssemblyInfo.cs
+++ b/ReallySimpleFeatureToggle.Web.Mvc/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("ReallySimpleFeatureToggle.Web.Mvc")]
@@ -14,3 +15,4 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: InternalsVisibleTo("ReallySimpleFeatureToggle.Web.Mvc.Test.Unit")]

--- a/ReallySimpleFeatureToggle.sln
+++ b/ReallySimpleFeatureToggle.sln
@@ -24,6 +24,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReallySimpleFeatureToggle.W
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReallySimpleFeatureToggle.Web.Mvc", "ReallySimpleFeatureToggle.Web.Mvc\ReallySimpleFeatureToggle.Web.Mvc.csproj", "{9D604F95-FFF7-463F-A583-05377787E3EF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReallySimpleFeatureToggle.Web.Mvc.Test.Unit", "ReallySimpleFeatureToggle.Web.Mvc.Test.Unit\ReallySimpleFeatureToggle.Web.Mvc.Test.Unit.csproj", "{28A15B26-1A93-45FB-A06E-8FE0B85E726B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -58,6 +60,10 @@ Global
 		{9D604F95-FFF7-463F-A583-05377787E3EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9D604F95-FFF7-463F-A583-05377787E3EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9D604F95-FFF7-463F-A583-05377787E3EF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{28A15B26-1A93-45FB-A06E-8FE0B85E726B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{28A15B26-1A93-45FB-A06E-8FE0B85E726B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{28A15B26-1A93-45FB-A06E-8FE0B85E726B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{28A15B26-1A93-45FB-A06E-8FE0B85E726B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Tenant didn't appear to be supported by the MvcPlugin (FeatureAttribute, HtmlHelpers).  So I added tenant as a constructor param to the MvcPlugin and passed it along to the GetFeatureConfiguration call.  Included a couple of unit tests as well.
